### PR TITLE
Add support for publishing a package that isn't at repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ you'll need to configure that workflow yourself. You can look to the
   * All other changes will increment the patch version.
 * Publish to npm using the configured token.
 * Push a tag for the new version to GitHub.
+
+### Additional Configuration
+
+* If your `package.json` is not in the repo's root directory, set `PACKAGE_PATH` env variable and the publish commands will be run from that package directory.
+  ```
+  - name: Publish
+      uses: mikeal/merge-release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        PACKAGE_PATH: ./packages/my-package
+  ```

--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -12,7 +12,8 @@ const get = bent('json', process.env.NPM_REGISTRY_URL || 'https://registry.npmjs
 
 const event = JSON.parse(fs.readFileSync('/github/workflow/event.json').toString())
 
-let pkg = require(path.join(process.cwd(), 'package.json'))
+let packagePath = process.env.PACKAGE_PATH || process.cwd()
+let pkg = require(path.join(packagePath, 'package.json'))
 
 const run = async () => {
   if (!process.env.NPM_AUTH_TOKEN) throw new Error('Merge-release requires NPM_AUTH_TOKEN')
@@ -52,6 +53,7 @@ const run = async () => {
 
   const exec = str => process.stdout.write(execSync(str))
 
+  exec(`cd ${packagePath}`)
   let current = execSync(`npm view ${pkg.name} version`).toString()
   exec(`npm version --allow-same-version=true --git-tag-version=false ${current} `)
   console.log('current:', current, '/', 'version:', version)


### PR DESCRIPTION
Unblocks using this Github Action in a repo where the package to publish isn't at the root directory of the repo. For example, if a repo has a package in `./packages/my-package`.