### PR TITLE
Leave package access scope to the package configuration

### DIFF
--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -57,7 +57,7 @@ const run = async () => {
   console.log('current:', current, '/', 'version:', version)
   let newVersion = execSync(`npm version --git-tag-version=false ${version}`).toString()
   console.log('new version:', newVersion)
-  exec(`npm publish --access=public`)
+  exec(`npm publish`)
   exec(`git checkout package.json`) // cleanup
   exec(`git tag ${newVersion}`)
   exec(`git push merge-release --tags`)


### PR DESCRIPTION
We just got badly burnt by the current behaviour of this plugin.

Scoped packages, e.g. `@org/package` are restricted by default, e.g. an `npm publish` publishes them privately whilst the default behaviour of npm for a unscoped package is to publish it publicly; e.g. `package` will be release `public` with a simple `npm publish`.
This plugin diverts from the default npm behaviour in that it releases all packages, independent of their configuration or the sane npm default, publicly.

references #8 

cc @joshua-leyshon-canva