### PR TITLE
Added functionality for mono-repos (different src and dist folders)

### DIFF
--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -61,7 +61,7 @@ const run = async () => {
   let currentVersion = execSync(`npm view ${pkg.name} version`, {cwd: srcPackageDir}).toString()
   exec(`npm version --allow-same-version=true --git-tag-version=false ${currentVersion} `, srcPackageDir)
   console.log('current:', currentVersion, '/', 'version:', version)
-  let newVersion = execSync(`npm version --git-tag-version=false ${version}`, srcPackageDir).toString()
+  let newVersion = execSync(`npm version --git-tag-version=false ${version}`, {cwd: srcPackageDir}).toString()
   exec(`npm version --allow-same-version=true --git-tag-version=false ${newVersion} `, deployDir)
   console.log('new version:', newVersion)
   exec(`npm publish`, deployDir)


### PR DESCRIPTION
**Scope**
Added functionality for deploying a package within a subdirectory in a monorepo. Similar to PR #7, but here's my changes anyway...

**Features**
In mono repos the `src` directory and compiled `dist` directory are usually in different folders. So I added the 2 environment variables:

- `SRC_PACKAGE_DIR` (where the src package.json is to increment)
- `DEPLOY_DIR` (where the dist package.json is to run `npm publish`)

In angular development it's convention to use a projects folder for the src code and a dist folder for the builds.

Here's a working snippet using a forked version of this repo:

``` yaml
- name: Publish
      if: github.ref == 'refs/heads/master'
      uses: benwinding/merge-release@master
      env:
        DEPLOY_DIR: dist/ngx-firestate
        SRC_PACKAGE_DIR: projects/ngx-firestate
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
```

Cheers for making this anyway, hope this PR helps someone else :+1: