### PR TITLE
Allow custom npmrc file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,15 @@
 
 set -e
 
-if [ -n "$NPM_AUTH_TOKEN" ]; then
+# Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
+NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
+
+if [ -n "$NPM_CUSTOM_NPMRC" ]; then
+  # Use a fully-formed npmrc file if provided
+  echo "$NPM_CUSTOM_NPMRC" > "$NPM_CONFIG_USERCONFIG"
+
+  chmod 0600 "$NPM_CONFIG_USERCONFIG"
+elif [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
   NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"


### PR DESCRIPTION
### SUMMARY

Allow caller of the action to pass in a custom .npmrc file.

### DETAILS

By passing in a new `NPM_CUSTOM_NPMRC` variable, the user can use a fully-formed .npmrc file (likely imported from `${{secrets}}`) to publish with, instead of crafting it using the various registry/auth token/etc. fields.

The use case here is interacting with a registry like private Artifactory (jfrog), which is somewhat non-standard and requires additional fields in the npmrc file to function properly.  This change allows a private package being published to jfrog to use the action by passing in a secret npmrc file, while still taking advantage of the rest of the logic (bump version, tag, publish, etc.).
