### PR TITLE
Add step output "version" parameter for other parts of the workflow

### DIFF
--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -60,6 +60,8 @@ const run = async () => {
   exec(`npm publish`)
   exec(`git checkout package.json`) // cleanup
   exec(`git tag ${newVersion}`)
+  exec(`echo "::set-output name=version::${newVersion}"`) // set action event.{STEP_ID}.output.version
+  
   /*
   const env = process.env
   const remote = `https://${env.GITHUB_ACTOR}:${env.GITHUB_TOKEN}@github.com/${env.GITHUB_REPOSITORY}.git`

--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -40,7 +40,7 @@ const run = async () => {
     }
   }
   if (!latest) {
-    messages = event.commits.map(commit => commit.message + '\n' + commit.body)
+    messages = (event.commits || []).map(commit => commit.message + '\n' + commit.body)
   }
 
   let version = 'patch'


### PR DESCRIPTION
This adds the `newVersion` variable to an output variable in the Workflow context. It simply uses [the workflow command detailed here](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter). 

Below shows the use-case I'm using it for _(leaving a comment of the version deployed)_. I've been testing it with my own deployment of this [github action](https://github.com/benwinding/merge-release) and [npm package](https://www.npmjs.com/package/@benwinding/merge-release)

[Link to Deploy action](https://github.com/benwinding/firecache/blob/master/.github/workflows/deploy.yml)
![image](https://user-images.githubusercontent.com/11782590/79585035-5ee7db80-810e-11ea-92a4-4586b9aa6592.png)


[Link to Flow Run](https://github.com/benwinding/firecache/runs/595687684)
![image](https://user-images.githubusercontent.com/11782590/79584199-3ad7ca80-810d-11ea-88d3-2702360242e7.png)

[Link to PR](https://github.com/benwinding/firecache/pull/8)
![image](https://user-images.githubusercontent.com/11782590/79584102-15e35780-810d-11ea-825b-93eafc6f0caa.png)

Let me know what you think!
