### PR TITLE
Adds option to only allow commits from a specific path to trigger the release

### DIFF
--- a/merge-release-run.js
+++ b/merge-release-run.js
@@ -35,8 +35,12 @@ const run = async () => {
     if (latest.gitHead === process.env.GITHUB_SHA) return console.log('SHA matches latest release, skipping.')
     if (latest.gitHead) {
       try {
-        let logs = await getlog({ from: latest.gitHead, to: process.env.GITHUB_SHA })
+        const allowPath = process.env.ALLOW_PATH
+        let logs = await getlog({ from: latest.gitHead, to: process.env.GITHUB_SHA, file: allowPath })
         messages = logs.all.map(r => r.message + '\n' + r.body)
+        if (allowPath && messages.length === 0) {
+          return console.log(`No commits founds within path: ${allowPath}, skipping.`)
+        }
       } catch (e) {
         latest = null
       }


### PR DESCRIPTION
This restrict the commits that are inspected to only the ones that have the specific path.

My use-case is the following:

I'm managing a mono-repo which has two packages: `package-1` and `package-2`.
What I want to accomplish is to avoid "BREAKING CHANGE" commits of `package-1` to increase the major version of `package-2`. As a bonus, this would also prevent releases from `package-1` when the commits only touched `package-2` files.

```yml
- uses: mikeal/merge-release@master
  env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
      DEPLOY_DIR: packages/insights-common-typescript
      SRC_PACKAGE_DIR: packages/insights-common-typescript
      ALLOW_PATH: packages/insights-common-typescript
```