### PR TITLE
Write to deployDir/package.json when updating version

### DIFF
--- a/src/merge-release-run.js
+++ b/src/merge-release-run.js
@@ -70,6 +70,7 @@ const run = async () => {
   const setVersion = version => {
     const json = execSync(`jq '.version="${version}"' package.json`, { cwd: srcPackageDir })
     fs.writeFileSync(path.join(srcPackageDir, 'package.json'), json)
+    fs.writeFileSync(path.join(deployDir, 'package.json'), json)
   }
 
   let currentVersion = execSync(`npm view ${pkg.name} version`, { cwd: srcPackageDir }).toString()

--- a/src/merge-release-run.js
+++ b/src/merge-release-run.js
@@ -70,7 +70,11 @@ const run = async () => {
   const setVersion = version => {
     const json = execSync(`jq '.version="${version}"' package.json`, { cwd: srcPackageDir })
     fs.writeFileSync(path.join(srcPackageDir, 'package.json'), json)
-    fs.writeFileSync(path.join(deployDir, 'package.json'), json)
+
+    if (deployDir !== './') {
+      const deployJson = execSync(`jq '.version="${version}"' package.json`, { cwd: deployDir })
+      fs.writeFileSync(path.join(deployDir, 'package.json'), deployJson)
+    }
   }
 
   let currentVersion = execSync(`npm view ${pkg.name} version`, { cwd: srcPackageDir }).toString()


### PR DESCRIPTION
This is related to #19 - in particular, it helps with the [pika/pack](https://github.com/pikapkg/pack) workflow.

When publishing a subfolder, the subfolder contains its own `package.json` file, which needs its `version` updated; or it will try to publish the `0.0.0-dev` (or similar placeholder) version.