### PR TITLE
docs: add note about using !: to rev the major

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ you'll need to configure that workflow yourself. You can look to the
   * If the package hasn't been published or the prior publish does not include a git hash, we'll
     only pull the commit data that triggered the action.
 * Based on the commit messages, increment the version from the lastest release.
-  * If the string "BREAKING CHANGE" is found anywhere in any of the commit messages or descriptions the major 
+  * If the strings "BREAKING CHANGE" or "!:" are found anywhere in any of the commit messages or descriptions the major 
     version will be incremented.
   * If a commit message begins with the string "feat" then the minor version will be increased. This works
     for most common commit metadata for feature additions: `"feat: new API"` and `"feature: new API"`.


### PR DESCRIPTION
#39 added support for using `!:` to increment the major version on release but it's not documented anywhere.

The change just adds a note to the readme letting users know it's a feature.